### PR TITLE
fix as the compact pdf was throwing a warning that pdf was undefined

### DIFF
--- a/src/View/PdfView.php
+++ b/src/View/PdfView.php
@@ -48,6 +48,8 @@ class PdfView extends View {
 		$this->pdf = new Dompdf($this->config);
 		$this->pdf->setPaper($this->config['size'], $this->config['orientation']);
 
+        $pdf = $this->pdf;
+
         $this->set(compact('pdf'));
 
 		$this->pdf->loadHtml(parent::render($view, $layout));


### PR DESCRIPTION
If this is not the correct way of reassigning a class variable in the compact() then let me know